### PR TITLE
Additional trigger event from `SlotItemHandler`

### DIFF
--- a/src/main/java/net/minecraftforge/event/entity/player/ItemTakeEvent.java
+++ b/src/main/java/net/minecraftforge/event/entity/player/ItemTakeEvent.java
@@ -12,7 +12,7 @@ public class ItemTakeEvent extends PlayerEvent
 {
 
 	/**
-	 * This event is fired in {@link net.minecraft.inventory.Slot#canTakeStack(EntityPlayer)} when a player clicks on an item.
+	 * This event is fired in {@link net.minecraft.inventory.Slot#canTakeStack(EntityPlayer)} and {@link net.minecraftforge.items.SlotItemHandler#canTakeStack(EntityPlayer)} when a player clicks on an item.
 	 */
 	@Nonnull
 	private final ItemStack itemStack;

--- a/src/main/java/net/minecraftforge/items/SlotItemHandler.java
+++ b/src/main/java/net/minecraftforge/items/SlotItemHandler.java
@@ -126,7 +126,8 @@ public class SlotItemHandler extends Slot
     @Override
     public boolean canTakeStack(EntityPlayer playerIn)
     {
-        return !this.getItemHandler().extractItem(index, 1, true).isEmpty();
+        net.minecraft.util.EnumActionResult cancelResult = net.minecraftforge.common.ForgeHooks.onItemTake(playerIn, this.getStack());
+        return cancelResult == null && !this.getItemHandler().extractItem(index, 1, true).isEmpty();
     }
 
     @Override


### PR DESCRIPTION
Added additional triggering of `ItemTakeEvent`. Many mods make use of `IItemHandler` inventories, which in turn use `SlotItemHandler` instead of `Slot`.